### PR TITLE
Adds env vars for serverless deploy and single user selection mode

### DIFF
--- a/app/.env.development.sample
+++ b/app/.env.development.sample
@@ -1,0 +1,3 @@
+REACT_APP_USERS_API=https://w2srtgwf0m.execute-api.us-east-1.amazonaws.com/dev/users
+REACT_APP_TASKS_API=https://r6h74drpa2.execute-api.us-east-1.amazonaws.com/dev/tasks
+REACT_APP_SOCKET_DNS=http://ec2-34-229-16-49.compute-1.amazonaws.com:9000

--- a/app/src/TaskNotificationScreen.tsx
+++ b/app/src/TaskNotificationScreen.tsx
@@ -12,6 +12,7 @@ import {
   WithStyles,
   withStyles,
 } from '@material-ui/core/styles'
+import Typography from '@material-ui/core/Typography/Typography'
 import CloudDone from '@material-ui/icons/CloudDone'
 import CloudUpload from '@material-ui/icons/CloudUpload'
 import * as React from 'react'
@@ -47,9 +48,7 @@ interface TaskNotificationScreenState {
   users: User[]
 }
 
-const SERVER_URL =
-  process.env.SERVER_URL ||
-  'http://ec2-34-229-16-49.compute-1.amazonaws.com:9000'
+const SERVER_URL = process.env.REACT_APP_SOCKET_DNS!
 
 class TaskNotificationScreen extends React.Component<
   TaskNotificationScreenProps,
@@ -170,6 +169,10 @@ class TaskNotificationScreen extends React.Component<
         alignItems="center"
         className={classes.root}
       >
+        <Typography variant="headline" gutterBottom={true}>
+          Serverless Task Notification
+        </Typography>
+
         <Grid item={true} xs={12} className={classes.taskFormRoot}>
           <AddTaskForm
             users={this.state.users}

--- a/app/src/components/AddTaskForm/AddTaskForm.tsx
+++ b/app/src/components/AddTaskForm/AddTaskForm.tsx
@@ -15,6 +15,7 @@ import { NotificationType } from '../../service/model/Task'
 import { User } from '../../service/model/User'
 import MentionFieldController, {
   CaretPosition,
+  ChangeCallback,
 } from '../MentionFieldController/MentionFieldController'
 import RemovableUserAvatar from '../RemovableUserAvatar/RemovableUserAvatar'
 import SelectUserMenu from '../SelectUserMenu/SelectUserMenu'
@@ -81,6 +82,18 @@ class AddTaskForm extends React.Component<AddTaskFormProps, AddTaskFormState> {
     }
   }
 
+  handleOnSelect: ChangeCallback<User> = ([user]) => {
+    this.setState(({ notificationType }) => ({
+      notificationType: !user
+        ? notificationType
+        : ['email', 'both'].includes(notificationType) && !user.email
+          ? 'sms'
+          : ['sms', 'both'].includes(notificationType) && !user.phone
+            ? 'email'
+            : notificationType,
+    }))
+  }
+
   handleNotificationChange: ChangeEventHandler<HTMLInputElement> = ev => {
     const type = ev.target.value as NotificationType
 
@@ -104,6 +117,7 @@ class AddTaskForm extends React.Component<AddTaskFormProps, AddTaskFormState> {
     return (
       <MentionFieldController<User>
         itemToString={user => (user ? user.name : 'empty')}
+        onSelect={this.handleOnSelect}
       >
         {({
           getRootProps,
@@ -149,7 +163,7 @@ class AddTaskForm extends React.Component<AddTaskFormProps, AddTaskFormState> {
                     inputProps={getInputProps()}
                     InputLabelProps={getLabelProps()}
                     inputRef={this.inputRef}
-                    placeholder="What needs to be done? Tag users typing @"
+                    placeholder="What needs to be done? Tag an user typing @"
                   />
                 </Grid>
                 <Button
@@ -181,6 +195,10 @@ class AddTaskForm extends React.Component<AddTaskFormProps, AddTaskFormState> {
                               this.state.notificationType,
                             )}
                             onChange={this.handleNotificationChange}
+                            disabled={
+                              selectedItems.length > 0 &&
+                              !selectedItems[0].phone
+                            }
                             value="sms"
                           />
                         }
@@ -193,6 +211,10 @@ class AddTaskForm extends React.Component<AddTaskFormProps, AddTaskFormState> {
                               this.state.notificationType,
                             )}
                             onChange={this.handleNotificationChange}
+                            disabled={
+                              selectedItems.length > 0 &&
+                              !selectedItems[0].email
+                            }
                             value="email"
                           />
                         }

--- a/app/src/components/MentionFieldController/MentionFieldController.tsx
+++ b/app/src/components/MentionFieldController/MentionFieldController.tsx
@@ -20,7 +20,7 @@ interface ProvidedState<T> extends ControllerStateAndHelpers<T> {
 
 type ChildrenFunction<T> = (options: ProvidedState<T>) => React.ReactNode
 
-type ChangeCallback<T> = (
+export type ChangeCallback<T> = (
   selectedItems: T[],
   stateAndHelpers: ProvidedState<T>,
 ) => void
@@ -84,7 +84,8 @@ class MentionFieldController<T> extends React.Component<Props<T>, State<T>> {
   removeItem: RemoveItem<T> = (item, cb) => {
     this.setState(
       ({ selectedItems }) => ({
-        selectedItems: selectedItems.filter(i => i !== item),
+        // selectedItems: selectedItems.filter(i => i !== item),
+        selectedItems: [],
       }),
       cb,
     )
@@ -93,7 +94,7 @@ class MentionFieldController<T> extends React.Component<Props<T>, State<T>> {
   addSelectedItem(item: T, cb: () => void) {
     this.setState(
       ({ selectedItems }) => ({
-        selectedItems: [...selectedItems, item],
+        selectedItems: [item],
       }),
       cb,
     )

--- a/app/src/service/model/User.ts
+++ b/app/src/service/model/User.ts
@@ -1,5 +1,6 @@
 export interface User {
   id: string
   name: string
-  email: string
+  email?: string
+  phone?: string
 }

--- a/app/src/service/task.service.ts
+++ b/app/src/service/task.service.ts
@@ -2,8 +2,7 @@ import axios from 'axios'
 import * as urlJoin from 'url-join'
 import { CreateTaskPayload, Task } from './model/Task'
 
-const TASKS_RESOURCE_ENDPOINT =
-  'https://r6h74drpa2.execute-api.us-east-1.amazonaws.com/dev/tasks'
+const TASKS_RESOURCE_ENDPOINT = process.env.REACT_APP_TASKS_API
 
 const tasks = axios.create({
   baseURL: TASKS_RESOURCE_ENDPOINT,

--- a/app/src/service/user.service.ts
+++ b/app/src/service/user.service.ts
@@ -1,8 +1,7 @@
 import axios from 'axios'
 import { User } from './model/User'
 
-const USERS_RESOURCE_ENDPOINT =
-  'https://w2srtgwf0m.execute-api.us-east-1.amazonaws.com/dev/users'
+const USERS_RESOURCE_ENDPOINT = process.env.REACT_APP_USERS_API
 
 export const getUsers = async (): Promise<User[]> => {
   const { data } = await axios.get('/', {


### PR DESCRIPTION
@nerney Can you rename the env vars provided to the frontend to the ones in app/.env.development.sample? 

We are required by our build script to use the `REACT_APP_` prefix: https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#adding-custom-environment-variables